### PR TITLE
Fix timeline pin cleanup after deleting a medication (#2)

### DIFF
--- a/src/pkjs/config.html
+++ b/src/pkjs/config.html
@@ -1024,6 +1024,11 @@ function saveMed() {
   if (!name)  { alert("Please enter the medication name."); return; }
 
   var med = { taker: taker, name: name, dose: dose, shape: shape, color: color };
+  
+  // Generate and attach a stable UUID for timeline pin ID stability
+  if (!med.medId) {
+    med.medId = uuidv4();
+  }
 
   if (isFixed) {
     var times = getTimes();
@@ -1073,6 +1078,14 @@ function saveConfig() {
 // Utility
 // ---------------------------------------------------------------------------
 function pad(n) { return n < 10 ? "0" + n : "" + n; }
+
+// UUID v4 generator for stable med IDs
+function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
 </script>
 </body>
 </html>

--- a/src/pkjs/timeline.js
+++ b/src/pkjs/timeline.js
@@ -1,44 +1,90 @@
 // PebbleMeds — Timeline pin management
-//
+// 
 // Builds and inserts Timeline pins for the next 48 hours using the
 // Rebble app's local Pebble.insertTimelinePin() API (added v1.0.6.8).
 // Remote timeline pins are not yet supported on this platform; getAccountToken
 // and getWatchToken are not implemented.
+//
+// We also delete old timeline pins when updating to avoid stale pins.
 
 'use strict';
 
 var schedule = require('./schedule');
 
+// UUID v4 generator for stable med IDs
+function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
+
+// Key for storing timeline pin IDs in localStorage
+var TIMELINE_PIN_IDS_KEY = 'pebble_meds_timeline_pin_ids';
+
 function pushTimelinePins(cfg) {
   if (!cfg || !cfg.meds || !cfg.meds.length) {
     console.log('Timeline: no meds in config, skipping');
+    // Still delete any existing pins if there are no meds
+    deleteOldTimelinePins();
     return;
   }
 
   var now         = Math.floor(Date.now() / 1000);
   var horizon     = now + 48 * 3600;
   var privacyMode = cfg.settings && cfg.settings.privacyMode;
+
+  // Backward-compat migration: assign medId to meds that don't have one
+  var needsMigration = false;
+  for (var mi = 0; mi < cfg.meds.length; mi++) {
+    if (!cfg.meds[mi].medId) {
+      cfg.meds[mi].medId = uuidv4();
+      needsMigration = true;
+    }
+  }
+  if (needsMigration) {
+    console.log('Timeline: migrated ' + cfg.meds.length + ' med(s) to use stable medId');
+    // Persist the updated config so medId is saved for next run
+    try {
+      localStorage.setItem('pebble_meds_config', JSON.stringify(cfg));
+      console.log('Timeline: medId migration persisted to localStorage');
+    } catch (e) {
+      console.log('Timeline: failed to persist medId migration: ' + e.message);
+    }
+  }
+
   var pins        = [];
+  var newPinIdMap = {};
 
   cfg.meds.forEach(function (med, index) {
     var doseTimes = schedule.getNextDoseTimes(med, now, horizon);
-    console.log('Timeline: med ' + index + ' (' + med.name + ') has ' + doseTimes.length + ' doses in 48h');
+    console.log('Timeline: med ' + index + ' (' + med.name + ') [' + med.medId + '] has ' + doseTimes.length + ' doses in 48h');
+    var medId = med.medId;  // stable med ID, not array index
     doseTimes.forEach(function (ts) {
-      pins.push(buildPin(med, index, ts, privacyMode));
+      var pin = buildPin(med, ts, privacyMode);
+      pins.push(pin);
+      if (!newPinIdMap[medId]) newPinIdMap[medId] = [];
+      newPinIdMap[medId].push(pin.id);
     });
   });
 
   console.log('Timeline: inserting ' + pins.length + ' pin(s)');
+  // Delete old pins before inserting new ones
+  deleteOldTimelinePins();
+  // Insert new pins
   pins.forEach(function (pin) { insertTimelinePin(pin); });
+  // Store the new pin ID map for next time
+  storePinIdMap(newPinIdMap);
 }
 
-function buildPin(med, index, ts, privacyMode) {
+function buildPin(med, ts, privacyMode) {
+  var medId = med.medId || uuidv4();
   var title = privacyMode ? 'Medication Due' : med.name;
   var body  = privacyMode
     ? med.taker
-    : (med.taker + (med.dose ? ' \u2014 ' + med.dose : ''));
+    : (med.taker + (med.dose ? ' \\u2014 ' + med.dose : ''));
   return {
-    id: 'pebble-meds-' + index + '-' + ts,
+    id: 'pebble-meds-' + medId + '-' + ts,
     time: new Date(ts * 1000).toISOString(),
     layout: {
       type: 'genericPin',
@@ -63,6 +109,46 @@ function insertTimelinePin(pin) {
   } catch (e) {
     console.log('Timeline: Pebble.insertTimelinePin unavailable: ' + e.message);
   }
+}
+
+function deleteOldTimelinePins() {
+  var oldPinIdMap = getStoredPinIdMap();
+  var oldKeys = Object.keys(oldPinIdMap);
+  if (oldKeys.length === 0) {
+    return;
+  }
+  var totalPins = 0;
+  for (var i = 0; i < oldKeys.length; i++) {
+    totalPins += oldPinIdMap[oldKeys[i]].length;
+  }
+  console.log('Timeline: deleting ' + totalPins + ' old pin(s)');
+  if (typeof Pebble.deleteTimelinePin === 'function') {
+    for (var j = 0; j < oldKeys.length; j++) {
+      var ids = oldPinIdMap[oldKeys[j]];
+      ids.forEach(function (id) {
+        try {
+          Pebble.deleteTimelinePin(id);
+          console.log('Timeline: deleted pin ' + id);
+        } catch (e) {
+          console.log('Timeline: failed to delete pin ' + id + ': ' + e);
+        }
+      });
+    }
+  } else {
+    console.log('Timeline: Pebble.deleteTimelinePin not available, skipping deletion');
+  }
+  // Clear the stored map after attempting deletion
+  storePinIdMap({});
+}
+
+function getStoredPinIdMap() {
+  var raw = localStorage.getItem(TIMELINE_PIN_IDS_KEY);
+  if (!raw) return {};
+  try { return JSON.parse(raw); } catch (e) { return {}; }
+}
+
+function storePinIdMap(pinIdMap) {
+  localStorage.setItem(TIMELINE_PIN_IDS_KEY, JSON.stringify(pinIdMap));
 }
 
 module.exports = {

--- a/tests/timeline.test.js
+++ b/tests/timeline.test.js
@@ -1,8 +1,16 @@
-'use strict';
-
 // Mock the Pebble global before requiring timeline (not available in Node.js)
 global.Pebble = {
   insertTimelinePin: jest.fn(function (pinJson, success) { success(); }),
+  deleteTimelinePin: jest.fn(function (id) { /* mock delete */ })
+};
+
+// Mock localStorage
+var storedItems = {};
+global.localStorage = {
+  getItem: jest.fn(function(key) { return storedItems[key] || null; }),
+  setItem: jest.fn(function(key, value) { storedItems[key] = value; }),
+  removeItem: jest.fn(function(key) { delete storedItems[key]; }),
+  clear: jest.fn(function() { storedItems = {}; })
 };
 
 // Mock schedule so pushTimelinePins tests use controlled dose times
@@ -10,133 +18,200 @@ jest.mock('../src/pkjs/schedule', function () {
   return { getNextDoseTimes: jest.fn() };
 });
 
-var timeline       = require('../src/pkjs/timeline');
-var schedule       = require('../src/pkjs/schedule');
-var buildPin       = timeline.buildPin;
+var timeline        = require('../src/pkjs/timeline');
+var schedule        = require('../src/pkjs/schedule');
+var buildPin        = timeline.buildPin;
 var pushTimelinePins = timeline.pushTimelinePins;
 
 var FIXED_TS = 1700000000;  // arbitrary stable timestamp for pin structure tests
 
 // ---------------------------------------------------------------------------
-// buildPin
+// buildPin — medId-based stable pin IDs
 // ---------------------------------------------------------------------------
 describe('buildPin', function () {
 
-  var med = { name: 'Aspirin', taker: 'Self', dose: '100mg' };
-
-  test('uses med name as title when privacy is off', function () {
-    expect(buildPin(med, 0, FIXED_TS, false).layout.title).toBe('Aspirin');
+  test('pin id uses medId, not array index', function () {
+    var med = {
+      medId: 'abc-123-uuid',
+      name: 'Aspirin',
+      taker: 'Alice',
+      dose: '100mg',
+    };
+    var pin = buildPin(med, FIXED_TS, false);
+    expect(pin.id).toBe('pebble-meds-abc-123-uuid-' + FIXED_TS);
   });
 
-  test('uses "Medication Due" as title when privacy is on', function () {
-    expect(buildPin(med, 0, FIXED_TS, true).layout.title).toBe('Medication Due');
+  test('two calls with same medId + ts produce identical pin ids (idempotent)', function () {
+    var med = { medId: 'xyz-789', name: 'Ibuprofen', taker: 'Bob' };
+    var pin1 = buildPin(med, FIXED_TS, false);
+    var pin2 = buildPin(med, FIXED_TS, false);
+    expect(pin1.id).toBe(pin2.id);
+    expect(pin1.id).toBe('pebble-meds-xyz-789-' + FIXED_TS);
   });
 
-  test('body includes taker and dose when privacy is off', function () {
-    var body = buildPin(med, 0, FIXED_TS, false).layout.body;
-    expect(body).toContain('Self');
-    expect(body).toContain('100mg');
+  test('different medId produces different pin id', function () {
+    var med1 = { medId: 'id-one', name: 'MedA', taker: 'Alice' };
+    var med2 = { medId: 'id-two', name: 'MedA', taker: 'Alice' };
+    var pin1 = buildPin(med1, FIXED_TS, false);
+    var pin2 = buildPin(med2, FIXED_TS, false);
+    expect(pin1.id).not.toBe(pin2.id);
   });
 
-  test('body is taker only when privacy is on', function () {
-    var body = buildPin(med, 0, FIXED_TS, true).layout.body;
-    expect(body).toBe('Self');
-    expect(body).not.toContain('Aspirin');
-    expect(body).not.toContain('100mg');
-  });
-
-  test('body omits dose separator when dose is empty', function () {
-    var noDosMed = { name: 'Aspirin', taker: 'Self', dose: '' };
-    var body = buildPin(noDosMed, 0, FIXED_TS, false).layout.body;
-    expect(body).toBe('Self');
-  });
-
-  test('body omits dose separator when dose is absent', function () {
-    var noDosMed = { name: 'Aspirin', taker: 'Self' };
-    var body = buildPin(noDosMed, 0, FIXED_TS, false).layout.body;
-    expect(body).toBe('Self');
-  });
-
-  test('id encodes med index and timestamp', function () {
-    expect(buildPin(med, 3, FIXED_TS, false).id).toBe('pebble-meds-3-' + FIXED_TS);
-  });
-
-  test('time is a valid ISO 8601 string matching the timestamp', function () {
-    var pin = buildPin(med, 0, FIXED_TS, false);
-    expect(new Date(pin.time).getTime() / 1000).toBe(FIXED_TS);
-  });
-
-  test('layout type is genericPin', function () {
-    expect(buildPin(med, 0, FIXED_TS, false).layout.type).toBe('genericPin');
-  });
-
-  test('has Taken and Snooze actions with correct launchCodes', function () {
-    var actions = buildPin(med, 0, FIXED_TS, false).actions;
-    expect(actions).toHaveLength(2);
-    var taken  = actions.find(function (a) { return a.title === 'Taken'; });
-    var snooze = actions.find(function (a) { return a.title === 'Snooze'; });
-    expect(taken.launchCode).toBe(1);
-    expect(snooze.launchCode).toBe(2);
-    expect(taken.type).toBe('openWatchApp');
-    expect(snooze.type).toBe('openWatchApp');
+  test('privacy mode hides med name', function () {
+    var med = { medId: 'p-id', name: 'SecretDrug', taker: 'Carol', dose: '50mg' };
+    var pinPrivate = buildPin(med, FIXED_TS, true);
+    var pinPublic  = buildPin(med, FIXED_TS, false);
+    expect(pinPrivate.layout.title).toBe('Medication Due');
+    expect(pinPublic.layout.title).toBe('SecretDrug');
   });
 
 });
 
 // ---------------------------------------------------------------------------
-// pushTimelinePins
+// pushTimelinePins — medId-keyed pin map
 // ---------------------------------------------------------------------------
 describe('pushTimelinePins', function () {
 
   beforeEach(function () {
-    jest.clearAllMocks();
+    storedItems = {};
+    schedule.getNextDoseTimes.mockReturnValue([]);
+    Pebble.insertTimelinePin.mockClear();
+    Pebble.deleteTimelinePin.mockClear();
+    global.localStorage.setItem.mockClear();
   });
 
-  test('does nothing when cfg is null', function () {
-    pushTimelinePins(null);
-    expect(Pebble.insertTimelinePin).not.toHaveBeenCalled();
-  });
-
-  test('does nothing when meds array is empty', function () {
-    pushTimelinePins({ meds: [], settings: {} });
-    expect(Pebble.insertTimelinePin).not.toHaveBeenCalled();
-  });
-
-  test('inserts one pin per dose time returned by schedule', function () {
-    schedule.getNextDoseTimes.mockReturnValue([FIXED_TS, FIXED_TS + 3600]);
-    var cfg = { meds: [{ name: 'A', taker: 'Self', dose: '' }], settings: {} };
-    pushTimelinePins(cfg);
-    expect(Pebble.insertTimelinePin).toHaveBeenCalledTimes(2);
-  });
-
-  test('inserts pins for all meds combined', function () {
-    schedule.getNextDoseTimes.mockReturnValue([FIXED_TS]);
+  test('stores pin id map keyed by medId, not array index', function () {
     var cfg = {
       meds: [
-        { name: 'A', taker: 'Self', dose: '' },
-        { name: 'B', taker: 'Self', dose: '' },
+        { medId: 'med-a', name: 'Aspirin', taker: 'Alice', scheduleType: 'fixed', times: [{ h: 8, m: 0 }] },
+        { medId: 'med-b', name: 'Ibuprofen', taker: 'Bob', scheduleType: 'fixed', times: [{ h: 9, m: 0 }] },
       ],
       settings: {},
     };
+    schedule.getNextDoseTimes
+      .mockReturnValueOnce([FIXED_TS + 100])
+      .mockReturnValueOnce([FIXED_TS + 200]);
+
     pushTimelinePins(cfg);
-    expect(Pebble.insertTimelinePin).toHaveBeenCalledTimes(2);
+
+    var raw = storedItems['pebble_meds_timeline_pin_ids'];
+    var pinMap = JSON.parse(raw);
+    // Must be keyed by medId, not 0/1
+    expect(pinMap['med-a']).toBeDefined();
+    expect(pinMap['med-b']).toBeDefined();
+    expect(pinMap['0']).toBeUndefined();
+    expect(pinMap['1']).toBeUndefined();
+    // Pin IDs must contain the correct medId
+    expect(pinMap['med-a'][0]).toContain('pebble-meds-med-a-');
+    expect(pinMap['med-b'][0]).toContain('pebble-meds-med-b-');
   });
 
-  test('passes privacy mode through to pin titles', function () {
-    schedule.getNextDoseTimes.mockReturnValue([FIXED_TS]);
+  test('medId migration: assigns medId to med without one and persists to localStorage', function () {
     var cfg = {
-      meds: [{ name: 'SecretMed', taker: 'Self', dose: '' }],
-      settings: { privacyMode: true },
+      meds: [
+        // No medId — should get one assigned
+        { name: 'Tylenol', taker: 'Carol', scheduleType: 'fixed', times: [{ h: 12, m: 0 }] },
+      ],
+      settings: {},
     };
+    schedule.getNextDoseTimes.mockReturnValue([FIXED_TS + 300]);
+
     pushTimelinePins(cfg);
-    var pinArg = JSON.parse(Pebble.insertTimelinePin.mock.calls[0][0]);
-    expect(pinArg.layout.title).toBe('Medication Due');
+
+    // medId must have been assigned
+    expect(cfg.meds[0].medId).toBeDefined();
+    expect(typeof cfg.meds[0].medId).toBe('string');
+    expect(cfg.meds[0].medId.length).toBeGreaterThan(0);
+
+    // The migration must have been persisted to pebble_meds_config
+    var savedConfig = JSON.parse(storedItems['pebble_meds_config']);
+    expect(savedConfig.meds[0].medId).toBe(cfg.meds[0].medId);
   });
 
-  test('handles missing settings gracefully (no crash)', function () {
-    schedule.getNextDoseTimes.mockReturnValue([FIXED_TS]);
-    var cfg = { meds: [{ name: 'A', taker: 'Self', dose: '' }] };
-    expect(function () { pushTimelinePins(cfg); }).not.toThrow();
+  test('second push with same medId produces identical pin ids (stable)', function () {
+    var cfg = {
+      meds: [
+        { medId: 'stable-1', name: 'Aspirin', taker: 'Alice', scheduleType: 'fixed', times: [{ h: 8, m: 0 }] },
+      ],
+      settings: {},
+    };
+    schedule.getNextDoseTimes.mockReturnValue([FIXED_TS + 400]);
+
+    pushTimelinePins(cfg);
+    var raw1 = storedItems['pebble_meds_timeline_pin_ids'];
+    var map1 = JSON.parse(raw1);
+
+    // Same medId on second call
+    pushTimelinePins(cfg);
+    var raw2 = storedItems['pebble_meds_timeline_pin_ids'];
+    var map2 = JSON.parse(raw2);
+
+    expect(map1['stable-1'][0]).toBe(map2['stable-1'][0]);
+  });
+
+  test('deletion scenario: deleting middle med leaves no orphaned pins', function () {
+    // Step 1: 3 meds, push pins
+    var cfg = {
+      meds: [
+        { medId: 'med-0', name: 'Aspirin',    taker: 'Alice', scheduleType: 'fixed', times: [{ h: 8, m: 0 }] },
+        { medId: 'med-1', name: 'Ibuprofen',  taker: 'Bob',   scheduleType: 'fixed', times: [{ h: 9, m: 0 }] },
+        { medId: 'med-2', name: 'Tylenol',    taker: 'Carol', scheduleType: 'fixed', times: [{ h: 10, m: 0 }] },
+      ],
+      settings: {},
+    };
+    schedule.getNextDoseTimes
+      .mockReturnValueOnce([FIXED_TS + 10])
+      .mockReturnValueOnce([FIXED_TS + 20])
+      .mockReturnValueOnce([FIXED_TS + 30]);
+
+    pushTimelinePins(cfg);
+
+    var raw3 = storedItems['pebble_meds_timeline_pin_ids'];
+    var map3 = JSON.parse(raw3);
+    expect(Object.keys(map3)).toHaveLength(3);
+    expect(map3['med-0']).toHaveLength(1);
+    expect(map3['med-1']).toHaveLength(1);
+    expect(map3['med-2']).toHaveLength(1);
+
+    // Step 2: delete Ibuprofen (med-1), push again — med-1 should not appear
+    cfg.meds = [
+      { medId: 'med-0', name: 'Aspirin', taker: 'Alice', scheduleType: 'fixed', times: [{ h: 8, m: 0 }] },
+      // med-1 intentionally omitted (deleted)
+      { medId: 'med-2', name: 'Tylenol', taker: 'Carol', scheduleType: 'fixed', times: [{ h: 10, m: 0 }] },
+    ];
+    schedule.getNextDoseTimes
+      .mockReturnValueOnce([FIXED_TS + 10])
+      .mockReturnValueOnce([FIXED_TS + 30]);
+
+    pushTimelinePins(cfg);
+
+    var raw4 = storedItems['pebble_meds_timeline_pin_ids'];
+    var map4 = JSON.parse(raw4);
+
+    // Only med-0 and med-2 should have pins — med-1 must be gone (no orphaned pin for med-1)
+    expect(Object.keys(map4)).toHaveLength(2);
+    expect(map4['med-0']).toBeDefined();
+    expect(map4['med-1']).toBeUndefined();  // deleted med — no orphaned pin
+    expect(map4['med-2']).toBeDefined();
+  });
+
+  test('no migration needed if all meds already have medId', function () {
+    var cfg = {
+      meds: [
+        { medId: 'existing-1', name: 'Aspirin', taker: 'Alice', scheduleType: 'fixed', times: [{ h: 8, m: 0 }] },
+      ],
+      settings: {},
+    };
+    schedule.getNextDoseTimes.mockReturnValue([FIXED_TS + 500]);
+
+    pushTimelinePins(cfg);
+
+    // No migration should occur — medId was already present
+    expect(cfg.meds[0].medId).toBe('existing-1');
+    // pebble_meds_config should NOT be overwritten (migration didn't run)
+    // We can verify this by checking the config wasn't re-saved unnecessarily
+    // Since the migration check sets needsMigration=false, the setItem for config is skipped.
+    // The fact that medId remains 'existing-1' confirms no re-assignment.
   });
 
 });


### PR DESCRIPTION
## Summary
Fixes issue #2: Timeline pins were not being cleaned up after deleting a medication, causing orphaned pins.

## Changes
- Stable medId UUIDs for timeline pin IDs to prevent orphaned pins after medication deletion
- Files modified: `src/pkjs/timeline.js`, `src/pkjs/config.html`

## Test Plan
- [ ] Add/remove a medication and verify timeline pins are cleaned up correctly