### PR TITLE
Heartbeat Tweaks

### DIFF
--- a/src/c/notifications.c
+++ b/src/c/notifications.c
@@ -103,7 +103,7 @@ void notifications_schedule_wakeups(void) {
         wakeup_schedule(snooze_t, WAKEUP_COOKIE_SNOOZE, false);
     }
 
-    wakeup_schedule(now + HEARTBEAT_INTERVAL_SECS, WAKEUP_COOKIE_HEARTBEAT, false);
+    wakeup_schedule(now + HEARTBEAT_INTERVAL_SECS, WAKEUP_COOKIE_HEARTBEAT, true);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/c/notifications.c
+++ b/src/c/notifications.c
@@ -133,7 +133,6 @@ void notifications_handle_wakeup(WakeupId id, int32_t cookie) {
 
     if (cookie == WAKEUP_COOKIE_HEARTBEAT) {
         notifications_schedule_wakeups();
-        dose_list_window_push();
         return;
     }
 


### PR DESCRIPTION
1. Do not show UI during heartbeat. This will prevent the app from taking focus every 6 hours.
2. Set the heartbeat to run if it was missed while the watch was off. I turn mine off while I sleep and I think this might be why I was missing some notifications